### PR TITLE
COMP: Remove invalid doxygen command arguments.

### DIFF
--- a/include/itkAnalyzeObjectEntry.h
+++ b/include/itkAnalyzeObjectEntry.h
@@ -548,8 +548,6 @@ public:
 protected:
   /**
    * \brief AnalyzeObjectEntry( ) is the default constructor, initializes to 0 or NULL
-   * \param none
-   * \return none
    * Possible Causes of Failure:
    * - unknown
    */
@@ -558,8 +556,6 @@ protected:
   /**
    * \brief ~AnalyzeObjectEntry( void ) is the destructor, which does nothing explicitly due to
    * no use of dynamic allocation
-   * \param none
-   * \return none
    * Possible Causes of Failure:
    * - unknown
    * \sa AnalyzeObjectEntry


### PR DESCRIPTION
For:

  /home/matt/src/ITK2/Modules/Remote/AnalyzeObjectMapIO/include/itkAnalyzeObjectEntry.h:600:
  warning: argument 'none' of command @param is not found in the argument list
  of itk::AnalyzeObjectEntry::AnalyzeObjectEntry(void)
  /home/matt/src/ITK2/Modules/Remote/AnalyzeObjectMapIO/include/itkAnalyzeObjectEntry.h:609:
  warning: argument 'none' of command @param is not found in the argument list
  of itk::AnalyzeObjectEntry::~AnalyzeObjectEntry(void)
