### PR TITLE
COMP: Use override annotations on overridden functions

### DIFF
--- a/include/itkAnalyzeObjectEntry.h
+++ b/include/itkAnalyzeObjectEntry.h
@@ -562,7 +562,7 @@ protected:
    */
   virtual ~AnalyzeObjectEntry( void );
 
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE;
 
 private:
   template <typename TValue>

--- a/include/itkAnalyzeObjectLabelMapImageIO.h
+++ b/include/itkAnalyzeObjectLabelMapImageIO.h
@@ -77,13 +77,13 @@ public:
    * \post Sets classes ImageIOBase::m_FileName variable to be FileNameToWrite
    * \return Returns true if this ImageIO can read the file specified.
    */
-  virtual bool CanReadFile(const char* FileNameToRead);
+  virtual bool CanReadFile(const char* FileNameToRead) ITK_OVERRIDE;
 
   /** Set the spacing and dimension information for the set filename. */
-  virtual void ReadImageInformation();
+  virtual void ReadImageInformation() ITK_OVERRIDE;
 
   /** Reads the data from disk into the memory buffer provided. */
-  virtual void Read(void* buffer);
+  virtual void Read(void* buffer) ITK_OVERRIDE;
 
   /*-------- This part of the interfaces deals with writing data. ----- */
 
@@ -93,14 +93,14 @@ public:
    * \post Sets classes ImageIOBase::m_FileName variable to be FileNameToWrite
    * \return Returns true if this ImageIO can write the file specified.
    */
-  virtual bool CanWriteFile(const char * FileNameToWrite);
+  virtual bool CanWriteFile(const char * FileNameToWrite) ITK_OVERRIDE;
 
   /** Set the spacing and dimension information for the set filename. */
-  virtual void WriteImageInformation();
+  virtual void WriteImageInformation() ITK_OVERRIDE;
 
   /** Writes the data to disk from the memory buffer provided. Make sure
    * that the IORegions has been set properly. */
-  virtual void Write(const void* buffer);
+  virtual void Write(const void* buffer) ITK_OVERRIDE;
 
   // Streaming not yet supported, so use the default base class to return the LargestPossibleRegion
 #if _USE_STREAMABLE_REGION_FOR_AOLM
@@ -110,7 +110,7 @@ public:
 
 #endif
 
-  virtual bool CanStreamRead()
+  virtual bool CanStreamRead() ITK_OVERRIDE
   {
     return false;
   }
@@ -118,7 +118,7 @@ public:
 protected:
   AnalyzeObjectLabelMapImageIO();
   ~AnalyzeObjectLabelMapImageIO();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE;
 
 private:
 

--- a/include/itkAnalyzeObjectLabelMapImageIOFactory.h
+++ b/include/itkAnalyzeObjectLabelMapImageIOFactory.h
@@ -40,9 +40,9 @@ public:
   typedef SmartPointer<const Self>            ConstPointer;
 
   /** Class methods used to interface with the registered factories. */
-  virtual const char * GetITKSourceVersion(void) const;
+  virtual const char * GetITKSourceVersion(void) const ITK_OVERRIDE;
 
-  virtual const char * GetDescription(void) const;
+  virtual const char * GetDescription(void) const ITK_OVERRIDE;
 
   /** Method for class instantiation. */
   itkFactorylessNewMacro(Self);
@@ -60,7 +60,7 @@ public:
 protected:
   AnalyzeObjectLabelMapImageIOFactory();
   ~AnalyzeObjectLabelMapImageIOFactory();
-  virtual void PrintSelf(std::ostream& os, Indent indent) const;
+  virtual void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE;
 
 private:
   AnalyzeObjectLabelMapImageIOFactory(const Self &); // purposely not implemented

--- a/include/itkAnalyzeObjectMap.h
+++ b/include/itkAnalyzeObjectMap.h
@@ -200,7 +200,7 @@ protected:
    */
   AnalyzeObjectMap( const AnalyzeObjectMap & /* rhs */ ); /*Explicitly not allowed*/
 
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE;
 
 private:
   /** Number of Objects in the object file */


### PR DESCRIPTION
Quiet warnings about overridden functions not being marked override