### PR TITLE
Clean remote modules

### DIFF
--- a/include/itkAnalyzeObjectEntry.h
+++ b/include/itkAnalyzeObjectEntry.h
@@ -48,6 +48,7 @@ constexpr int VERSION7{20050829};
 
 /**
  * \class AnalyzeObjectEntry
+ * \ingroup AnalyzeObjectLabelMap
  * \ingroup AnalyzeObjectMapIO
  * \brief This class encapsulates a single object in an Analyze object file
  */

--- a/include/itkAnalyzeObjectLabelMapImageIO.h
+++ b/include/itkAnalyzeObjectLabelMapImageIO.h
@@ -38,8 +38,8 @@ using AnalyzeObjectEntryArrayType = std::vector<AnalyzeObjectEntry::Pointer>;
 constexpr int NumberOfRunLengthElementsPerRead = 1;
 
 /** \class AnalyzeObjectLabelMapImageIO
- *   \ingroup AnalyzeObjectMapIO
- *
+ *  \ingroup AnalyzeObjectLabelMap
+ *  \ingroup AnalyzeObjectMapIO
  */
 class AnalyzeObjectLabelMap_EXPORT AnalyzeObjectLabelMapImageIO : public ImageIOBase
 {

--- a/include/itkAnalyzeObjectLabelMapImageIOFactory.h
+++ b/include/itkAnalyzeObjectLabelMapImageIOFactory.h
@@ -29,6 +29,7 @@
 namespace itk
 {
 /** \class AnalyzeObjectLabelMapImageIOFactory
+ *  \ingroup AnalyzeObjectLabelMap
  *  \ingroup AnalyzeObjectMapIO
  *  \brief Create instances of AnalyzeObjectLabelMapImageIO objects using an object factory.
  */

--- a/include/itkAnalyzeObjectLabelMapImageIOFactory.h
+++ b/include/itkAnalyzeObjectLabelMapImageIOFactory.h
@@ -36,6 +36,7 @@ namespace itk
 class AnalyzeObjectLabelMap_EXPORT AnalyzeObjectLabelMapImageIOFactory : public ObjectFactoryBase
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(AnalyzeObjectLabelMapImageIOFactory);
   /** Standard class type alias. */
   using Self = AnalyzeObjectLabelMapImageIOFactory;
   using Superclass = ObjectFactoryBase;
@@ -69,10 +70,6 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-private:
-  AnalyzeObjectLabelMapImageIOFactory(const Self &) = delete; // purposely not implemented
-  void
-  operator=(const Self &) = delete; // purposely not implemented
 };
 
 } // end namespace itk

--- a/include/itkAnalyzeObjectMap.h
+++ b/include/itkAnalyzeObjectMap.h
@@ -33,6 +33,7 @@ namespace itk
 using AnalyzeObjectEntryArrayType = std::vector<AnalyzeObjectEntry::Pointer>;
 
 /** \class AnalyzeObjectMap
+ *  \ingroup AnalyzeObjectLabelMap
  *  \ingroup AnalyzeObjectMapIO
  *  \brief A class that is an image with functions that let the user change aspects of the class.  This
  * is a templated class where most everything will depend on the Image type that is used.


### PR DESCRIPTION
This patch fixes the failing doxygen test. For several of the new enum classes, there is an absent `/ingroup` thus throwing the error. In addition, this removes any `delete` assignments in `private` and moves them to `public`. The only file affected is: `include/itkAnalyzeObjectLabelMapImageIOFactory.h`. We are able to make these changes due to the new updates in C++11 which were originally not possible in C++98.