### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkAnalyzeObjectMap.hxx
+++ b/include/itkAnalyzeObjectMap.hxx
@@ -21,7 +21,6 @@
 #ifndef itkAnalyzeObjectMap_hxx
 #define itkAnalyzeObjectMap_hxx
 
-#include "itkAnalyzeObjectMap.h"
 #include "itkImageRegionIterator.h"
 
 namespace itk


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

