### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro

### DIFF
--- a/include/itkAnalyzeObjectEntry.h
+++ b/include/itkAnalyzeObjectEntry.h
@@ -67,7 +67,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AnalyzeObjectEntry, Object);
+  itkOverrideGetNameOfClassMacro(AnalyzeObjectEntry);
 
   /**
    * \brief Copy

--- a/include/itkAnalyzeObjectLabelMapImageIO.h
+++ b/include/itkAnalyzeObjectLabelMapImageIO.h
@@ -58,7 +58,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AnalyzeObjectLabelMapImageIO, Superclass);
+  itkOverrideGetNameOfClassMacro(AnalyzeObjectLabelMapImageIO);
 
   /*-------- This part of the interfaces deals with reading data. ----- */
 

--- a/include/itkAnalyzeObjectLabelMapImageIOFactory.h
+++ b/include/itkAnalyzeObjectLabelMapImageIOFactory.h
@@ -54,7 +54,7 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AnalyzeObjectLabelMapImageIOFactory, ObjectFactoryBase);
+  itkOverrideGetNameOfClassMacro(AnalyzeObjectLabelMapImageIOFactory);
 
   /** Register one factory of this type  */
   static void

--- a/include/itkAnalyzeObjectMap.h
+++ b/include/itkAnalyzeObjectMap.h
@@ -57,7 +57,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AnalyzeObjectMap, TImage);
+  itkOverrideGetNameOfClassMacro(AnalyzeObjectMap);
 
   /**
    * \brief an assignment operator


### PR DESCRIPTION
Added two new macro's, intended to replace the old 'itkTypeMacro' and
'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual
'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337
